### PR TITLE
docs: add documentation for troubleshooting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,3 +16,4 @@
 - [Backup & Restore](./references/backup-restore.md)
 - [Storage](./references/storage.md)
 - [Updates](./references/updates.md)
+- [Troubleshooting](./references/troubleshooting.md)

--- a/docs/references/troubleshooting.md
+++ b/docs/references/troubleshooting.md
@@ -1,0 +1,6 @@
+# Troubleshooting
+
+## Flux: "Source artifact not found"
+
+In first check flux ressources `k get gitrepositories -A` and `k get helmrepositories -A`\
+If you have an error like "branch 'X' not found" it's certainly because you are in local branch or because the branch was been deleted from remote repository.


### PR DESCRIPTION
Just add `Troubleshooting` page on documentation to list common errors and their solutions to avoid to search at each.