### PR TITLE
chore: improve local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,3 +92,6 @@ vm-destroy: ## Destroying VM
 vm-recreate: ## (Re)create VM
 	$(MAKE) vm-destroy
 	$(MAKE) vm-create
+
+test-k9s: ## Run K9S for VM cluster
+	KUBECONFIG=./out/kubeconfig/baku.dev.yaml:./out/kubeconfig/salamandre.dev.yaml k9s

--- a/docs/installation/development-sandbox.md
+++ b/docs/installation/development-sandbox.md
@@ -138,8 +138,13 @@ For SSO (OpenID) apps the user is :
 You can export kubeconfig with following command :
 
 ```sh
+# Linux/Mac
+export KUBECONFIG=./out/kubeconfig/salamandre.dev.yaml:./out/kubeconfig/baku.dev.yaml
+# Windows
 export KUBECONFIG=./out/kubeconfig/salamandre.dev.yaml;./out/kubeconfig/baku.dev.yaml
 ```
+
+CF: [The KUBECONFIG environment variable](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#the-kubeconfig-environment-variable)
 
 ## Clean up
 


### PR DESCRIPTION
Correct a small error in documentation for `KUBECONFIG` like say [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#the-kubeconfig-environment-variable)

> The KUBECONFIG environment variable holds a list of kubeconfig files. For Linux and Mac, the list is colon-delimited. For Windows, the list is semicolon-delimited.

So I have added this detail.

Also, I have added `test-k9s` command in makefile to simply execute k9s with development kubeconfig files. It's just a shortcut for `KUBECONFIG=.../baku.dev.yaml:.../salamandre.dev.yaml k9s`